### PR TITLE
betterErrorMessageIfLog4jConfigMissing

### DIFF
--- a/src/main/java/jsr223/docker/compose/DockerComposeScriptEngineFactory.java
+++ b/src/main/java/jsr223/docker/compose/DockerComposeScriptEngineFactory.java
@@ -20,11 +20,19 @@ public class DockerComposeScriptEngineFactory implements ScriptEngineFactory {
 
     private static final Map<String, Object> parameters = new HashMap<>();
 
+    private static final String log4jConfigurationFile = "config/log/scriptengines.properties";
+
     public DockerComposeScriptEngineFactory() {
         // This is the entrypoint of the script engine
         // configure the logger here, quick and dirty
-        org.apache.log4j.PropertyConfigurator.configure(getClass()
-        .getClassLoader().getResourceAsStream("config/log/scriptengines.properties"));
+        try {
+            org.apache.log4j.PropertyConfigurator.configure(getClass()
+            .getClassLoader().getResourceAsStream(log4jConfigurationFile));
+        } catch (NullPointerException e) {
+            System.err.println("Log4j configuration file not found: "+ log4jConfigurationFile +
+            ". Any output for the docker-compose script engine is disabled.");
+        }
+
 
         parameters.put(ScriptEngine.NAME, this.NAME);
         parameters.put(ScriptEngine.ENGINE_VERSION, this.ENGINE_VERSION);


### PR DESCRIPTION
Add error message if log4j scripengine config is missing, instead of silently failing. 
