### PR TITLE
Ensure compatibility with Java 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,9 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
-sourceCompatibility = 1.8
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 group = 'jsr223'
 
 defaultTasks 'jar'


### PR DESCRIPTION
Set source and target compatibility inside gradle file to java 7. That ensures that the script-engine runs on java 7 JVMs.
