### PR TITLE
Improve logging of script engine

### DIFF
--- a/src/main/java/jsr223/docker/compose/DockerComposeScriptEngine.java
+++ b/src/main/java/jsr223/docker/compose/DockerComposeScriptEngine.java
@@ -102,22 +102,21 @@ public class DockerComposeScriptEngine extends AbstractScriptEngine {
             return returnValue;
 
         } catch (IOException e) {
-            System.err.println("Filed to execute docker-compose.");
-            e.printStackTrace();
+            log.warn("Failed to execute Docker Compose.",e);
         } catch (InterruptedException e) {
             // Thread was interrupted somehow, now we need to make sure that
             // the container are stopped even though several interrupts could
             // occur. Therefore start a thread which will remove all container.
             // TODO: Start thread which will stop and remove container in the background
+            log.warn("Execution was terminated and container might need to be terminated manually.");
         } finally {
             // Delete configuration file
             composeYamlFile.delete();
         }
 
-
         return null;
     }
-    // TODO: Implement
+
     // TODO: Test
     @Override
     public Object eval(Reader reader, ScriptContext context) throws ScriptException {
@@ -127,7 +126,8 @@ public class DockerComposeScriptEngine extends AbstractScriptEngine {
         try {
             ProcessBuilderUtilities.pipe(reader, stringWriter);
         } catch (IOException e) {
-            e.printStackTrace();
+            log.warn("Filed to convert Reader into StringWriter. Not possible to execute Docker Compose script.");
+            log.debug("Filed to convert Reader into StringWriter. Not possible to execute Docker Compose script.", e);
         }
 
         return eval(stringWriter.toString(), context);
@@ -146,26 +146,38 @@ public class DockerComposeScriptEngine extends AbstractScriptEngine {
 
     /**
      * Adds all bindings which are from type @String to the environment map. All other bindings are printed
-     * with toString() to std.err with an error message.
+     * with toString() to log file.
      * @param bindings Bindings which will be read and added to environment.
-     * @param environment Map<String,String> which will get all Entry<String,String> from he @Bindings
+     * @param environment Map<String,String> which will get all Entry<String,String> from the @Bindings
      */
     private void addBindingToStringMap(@NotNull Bindings bindings, @NotNull Map<String, String> environment) {
         for(Map.Entry<String, Object> entry: bindings.entrySet()) {
             if (entry.getValue() instanceof String) {
-                environment.put(entry.getKey(),(String) entry.getValue());
-                System.out.println("Added binding: "+entry.getKey()+":"+entry.getValue().toString());
+                addEntryToEnvironmentWhichIsAPureString(environment, entry);
             } else { // Go through maps and add String String values to the environment map.
-                if (entry.getValue() instanceof Map<?, ?>)
-                    for (Map.Entry<?, ?> mapEntry :  ((Map<?,?>) entry.getValue()).entrySet()) {
-                        if (mapEntry.getValue() instanceof String && mapEntry.getKey() instanceof String) {
-                            environment.put((String) mapEntry.getKey(), (String) mapEntry.getValue());
-                            System.out.println("Added binding: "+mapEntry.getKey()+":"+mapEntry.getValue().toString());
-                        }
-                    }
-                else {
-                    System.err.println("Ignored binding: " + entry.getKey() + "(" + entry.getKey().getClass().getName() + "):" + entry.getValue().toString() + "(" + entry.getValue().getClass().getName() + ")");
-                }
+                AddEntryToEnvironmentOtherThanPureStrings(environment, entry);
+            }
+        }
+    }
+
+    private void addEntryToEnvironmentWhichIsAPureString(@NotNull Map<String, String> environment, Map.Entry<String, Object> entry) {
+        environment.put(entry.getKey(),(String) entry.getValue());
+        log.debug("Added binding: "+entry.getKey()+":"+entry.getValue().toString());
+    }
+
+    private void AddEntryToEnvironmentOtherThanPureStrings(@NotNull Map<String, String> environment, Map.Entry<String, Object> entry) {
+        if (entry.getValue() instanceof Map<?, ?>)
+            addEntryToEnvironmentWhichIsAMapContainingStrings(environment, entry);
+        else {
+            log.warn("Ignored binding: " + entry.getKey() + "(" + entry.getKey().getClass().getName() + "):" + entry.getValue().toString() + "(" + entry.getValue().getClass().getName() + ")");
+        }
+    }
+
+    private void addEntryToEnvironmentWhichIsAMapContainingStrings(@NotNull Map<String, String> environment, Map.Entry<String, Object> entry) {
+        for (Map.Entry<?, ?> mapEntry :  ((Map<?,?>) entry.getValue()).entrySet()) {
+            if (mapEntry.getValue() instanceof String && mapEntry.getKey() instanceof String) {
+                environment.put((String) mapEntry.getKey(), (String) mapEntry.getValue());
+                log.debug("Added binding: "+mapEntry.getKey()+":"+mapEntry.getValue().toString());
             }
         }
     }

--- a/src/main/java/jsr223/docker/compose/DockerComposeScriptEngine.java
+++ b/src/main/java/jsr223/docker/compose/DockerComposeScriptEngine.java
@@ -1,6 +1,7 @@
 package jsr223.docker.compose;
 
 import jsr223.docker.compose.utils.DockerComposePropertyLoader;
+import lombok.extern.log4j.Log4j;
 import org.jetbrains.annotations.NotNull;
 import processbuilder.SingletonProcessBuilderFactory;
 import processbuilder.utils.ProcessBuilderUtilities;
@@ -10,10 +11,31 @@ import java.io.*;
 import java.nio.file.FileAlreadyExistsException;
 import java.util.Map;
 
-
+@Log4j
 public class DockerComposeScriptEngine extends AbstractScriptEngine {
 
     private static final String DOCKER_HOST_PROPERTY_NAME = "DOCKER_HOST";
+    private static final String log4jConfigurationFile = "config/log/scriptengines.properties";
+
+
+    public DockerComposeScriptEngine() {
+        // This is the entrypoint of the script engine
+        // configure the logger here, quick and dirty
+        // Catch all exceptions to not sacrifice functionality for logging.
+        try {
+            org.apache.log4j.PropertyConfigurator.configure(getClass()
+                    .getClassLoader().getResourceAsStream(log4jConfigurationFile));
+        } catch (NullPointerException e) {
+            System.err.println("Log4j configuration file not found: "+ log4jConfigurationFile +
+                    ". Any output for the Docker Compose script engine is disabled.");
+        } catch (Exception e) {
+            System.err.println("Log4j initialization failed: "+ log4jConfigurationFile +
+                    ". Docker Compose script engine is functional but logging is disabled."+
+                    "Stacktrace is: ");
+            e.printStackTrace();
+        }
+
+    }
 
 
     @Override
@@ -153,10 +175,9 @@ public class DockerComposeScriptEngine extends AbstractScriptEngine {
     public Bindings createBindings() {
         return new SimpleBindings();
     }
-    // TODO: Implement
-    // TODO: Test
+
     @Override
     public ScriptEngineFactory getFactory() {
-        return null;
+        return new DockerComposeScriptEngineFactory();
     }
 }

--- a/src/main/java/jsr223/docker/compose/DockerComposeScriptEngineFactory.java
+++ b/src/main/java/jsr223/docker/compose/DockerComposeScriptEngineFactory.java
@@ -20,28 +20,12 @@ public class DockerComposeScriptEngineFactory implements ScriptEngineFactory {
 
     private static final Map<String, Object> parameters = new HashMap<>();
 
-    private static final String log4jConfigurationFile = "config/log/scriptengines.properties";
-
     public DockerComposeScriptEngineFactory() {
-        // This is the entrypoint of the script engine
-        // configure the logger here, quick and dirty
-        try {
-            org.apache.log4j.PropertyConfigurator.configure(getClass()
-            .getClassLoader().getResourceAsStream(log4jConfigurationFile));
-        } catch (NullPointerException e) {
-            System.err.println("Log4j configuration file not found: "+ log4jConfigurationFile +
-            ". Any output for the docker-compose script engine is disabled.");
-        }
-
 
         parameters.put(ScriptEngine.NAME, this.NAME);
         parameters.put(ScriptEngine.ENGINE_VERSION, this.ENGINE_VERSION);
         parameters.put(ScriptEngine.LANGUAGE, this.LANGUAGE);
         parameters.put(ScriptEngine.ENGINE, this.ENGINE);
-        parameters.put(ScriptEngine.LANGUAGE_VERSION,
-                DockerComposeUtilities.
-                getDockerComposeVersion(SingletonProcessBuilderFactory.getInstance()));
-
     }
 
 
@@ -77,7 +61,8 @@ public class DockerComposeScriptEngineFactory implements ScriptEngineFactory {
 
     @Override
     public String getLanguageVersion() {
-        return (String) parameters.get(ScriptEngine.LANGUAGE_VERSION);
+        return DockerComposeUtilities.
+                getDockerComposeVersion(SingletonProcessBuilderFactory.getInstance());
     }
 
     @Override

--- a/src/main/java/jsr223/docker/compose/DockerComposeScriptEngineFactory.java
+++ b/src/main/java/jsr223/docker/compose/DockerComposeScriptEngineFactory.java
@@ -22,10 +22,10 @@ public class DockerComposeScriptEngineFactory implements ScriptEngineFactory {
 
     public DockerComposeScriptEngineFactory() {
 
-        parameters.put(ScriptEngine.NAME, this.NAME);
-        parameters.put(ScriptEngine.ENGINE_VERSION, this.ENGINE_VERSION);
-        parameters.put(ScriptEngine.LANGUAGE, this.LANGUAGE);
-        parameters.put(ScriptEngine.ENGINE, this.ENGINE);
+        parameters.put(ScriptEngine.NAME, NAME);
+        parameters.put(ScriptEngine.ENGINE_VERSION, ENGINE_VERSION);
+        parameters.put(ScriptEngine.LANGUAGE, LANGUAGE);
+        parameters.put(ScriptEngine.ENGINE, ENGINE);
     }
 
 

--- a/src/main/java/jsr223/docker/compose/utils/DockerComposeUtilities.java
+++ b/src/main/java/jsr223/docker/compose/utils/DockerComposeUtilities.java
@@ -38,7 +38,6 @@ public class DockerComposeUtilities {
             // Extract output
             result = commandOutput.toString();
         } catch (IOException|InterruptedException|IndexOutOfBoundsException  e){
-            log.warn("Failed to retrieve docker compose version.");
             log.debug("Failed to retrieve docker compose version.", e);
         }
         return result;


### PR DESCRIPTION
The logging is too verbose and it printed into std.err and std.out. Logging was changed to silence and to append to the node logs. 
