### PR TITLE
Use docker compose down command for container removal. And minor impr…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 # Another version property is in DockerComposeScriptEngineFactory!!!
-version=0.1.14
+version=0.2.0

--- a/src/main/java/jsr223/docker/compose/DockerComposeCommandCreator.java
+++ b/src/main/java/jsr223/docker/compose/DockerComposeCommandCreator.java
@@ -1,47 +1,35 @@
 package jsr223.docker.compose;
 
+import jsr223.docker.compose.utils.DockerComposePropertyLoader;
+import lombok.NoArgsConstructor;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import jsr223.docker.compose.utils.DockerComposePropertyLoader;
-
+@NoArgsConstructor
 public class DockerComposeCommandCreator {
 
     // Constants
-    @lombok.Getter
-    private static String yamlFileName = "docker-compose.yml";
-    private static String filenameArgument = "-f";
-    private static String stopContainerArgument = "stop";
-    private static String removeContainerArgument = "rm";
-    private static String removeWithForceContainerArgument = "--force";
-    private static String setupContainerArgument = "up";
+    public static final String YAML_FILE_NAME = "docker-compose.yml";
+    public static final String FILENAME_ARGUMENT = "-f";
+    public static final String START_CONTAINER_ARGUMENT = "up";
+    public static final String STOP_AND_REMOVE_CONTAINER_ARGUMENT = "down";
+    public static final String VOLUMES_ARGUMENT = "--volumes";
 
 
     /**
-     * Construct the docker compose stop command.
+     * Construct docker compose down command.
      *
      * @return String array representing a command.
      */
-    public static String[] createDockerComposeStopCommand() {
+    public String[] createDockerComposeDownCommand() {
         List<String> command = new ArrayList<>();
         addSudoAndDockerComposeCommand(command);
 
-        command.add(stopContainerArgument);
-        return command.toArray(new String[command.size()]);
-    }
-
-    /**
-     * Construct docker compose remove command.
-     *
-     * @return String array representing a command.
-     */
-    public static String[] createDockerComposeRemoveCommand() {
-        List<String> command = new ArrayList<>();
-        addSudoAndDockerComposeCommand(command);
-
-        // Remove container with force; otherwise user input is expected.
-        command.add(removeContainerArgument);
-        command.add(removeWithForceContainerArgument);
+        // Stop and remove containers
+        command.add(STOP_AND_REMOVE_CONTAINER_ARGUMENT);
+        // Remove volumes with containers
+        command.add(VOLUMES_ARGUMENT);
         return command.toArray(new String[command.size()]);
     }
 
@@ -52,19 +40,19 @@ public class DockerComposeCommandCreator {
      * @return A String array which contains the command as a separate @String and each
      * argument as a separate String.
      */
-    public static String[] createDockerComposeExecutionCommand() {
+    public String[] createDockerComposeExecutionCommand() {
         List<String> command = new ArrayList<>();
         addSudoAndDockerComposeCommand(command);
 
 
         // Add filename argument
-        command.add(filenameArgument);
+        command.add(FILENAME_ARGUMENT);
 
         // Add filename
-        command.add(yamlFileName);
+        command.add(YAML_FILE_NAME);
 
         // Start container with argument
-        command.add(setupContainerArgument);
+        command.add(START_CONTAINER_ARGUMENT);
         return command.toArray(new String[command.size()]);
     }
 
@@ -74,7 +62,7 @@ public class DockerComposeCommandCreator {
      *
      * @param command List which gets the command(s) added.
      */
-    private static void addSudoAndDockerComposeCommand(List<String> command) {
+    private void addSudoAndDockerComposeCommand(List<String> command) {
         // Add sudo if necessary
         if (DockerComposePropertyLoader.getInstance().isUseSudo()) {
             command.add(DockerComposePropertyLoader.getInstance().getSudoCommand());

--- a/src/main/java/jsr223/docker/compose/DockerComposeScriptEngine.java
+++ b/src/main/java/jsr223/docker/compose/DockerComposeScriptEngine.java
@@ -4,6 +4,7 @@ import jsr223.docker.compose.bindings.MapBindingsAdder;
 import jsr223.docker.compose.bindings.StringBindingsAdder;
 import jsr223.docker.compose.file.write.ConfigurationFileWriter;
 import jsr223.docker.compose.utils.DockerComposePropertyLoader;
+import jsr223.docker.compose.utils.Log4jConfigurationLoader;
 import jsr223.docker.compose.yaml.VariablesReplacer;
 import lombok.extern.log4j.Log4j;
 import processbuilder.SingletonProcessBuilderFactory;
@@ -20,7 +21,7 @@ import java.util.Map;
 public class DockerComposeScriptEngine extends AbstractScriptEngine {
 
     private static final String DOCKER_HOST_PROPERTY_NAME = "DOCKER_HOST";
-    private static final String LOG4J_CONFIGURATION_FILE = "config/log/scriptengines.properties";
+
 
     private ProcessBuilderUtilities processBuilderUtilities = new ProcessBuilderUtilities();
     private VariablesReplacer variablesReplacer = new VariablesReplacer();
@@ -28,25 +29,12 @@ public class DockerComposeScriptEngine extends AbstractScriptEngine {
     private StringBindingsAdder stringBindingsAdder = new StringBindingsAdder(
             new MapBindingsAdder());
     private DockerComposeCommandCreator dockerComposeCommandCreator = new DockerComposeCommandCreator();
+    private Log4jConfigurationLoader log4jConfigurationLoader = new Log4jConfigurationLoader();
 
 
     public DockerComposeScriptEngine() {
-        // This is the entrypoint of the script engine
-        // configure the logger here, quick and dirty
-        // Catch all exceptions to not sacrifice functionality for logging.
-        try {
-            org.apache.log4j.PropertyConfigurator.configure(getClass()
-                    .getClassLoader().getResourceAsStream(LOG4J_CONFIGURATION_FILE));
-        } catch (NullPointerException e) { //NOSONAR
-            System.err.println("Log4j configuration file not found: " + LOG4J_CONFIGURATION_FILE + //NOSONAR
-                    ". Any output for the Docker Compose script engine is disabled."); //NOSONAR
-        } catch (Exception e) { //NOSONAR
-            System.err.println("Log4j initialization failed: " + LOG4J_CONFIGURATION_FILE + //NOSONAR
-                    ". Docker Compose script engine is functional but logging is disabled." + //NOSONAR
-                    "Stacktrace is: "); //NOSONAR
-            e.printStackTrace(); //NOSONAR
-        }
-
+        // This is the entry-point of the script engine
+        log4jConfigurationLoader.loadLog4jConfiguration();
     }
 
 

--- a/src/main/java/jsr223/docker/compose/DockerComposeScriptEngineFactory.java
+++ b/src/main/java/jsr223/docker/compose/DockerComposeScriptEngineFactory.java
@@ -1,39 +1,40 @@
 package jsr223.docker.compose;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import jsr223.docker.compose.utils.DockerComposeVersionGetter;
+import processbuilder.SingletonProcessBuilderFactory;
+import processbuilder.utils.ProcessBuilderUtilities;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
-
-import jsr223.docker.compose.utils.DockerComposeVersionGetter;
-import processbuilder.SingletonProcessBuilderFactory;
+import java.util.*;
 
 public class DockerComposeScriptEngineFactory implements ScriptEngineFactory {
 
-    private DockerComposeVersionGetter dockerComposeVersionGetter;
-
     // Script engine parameters
     private static final String NAME = "docker-compose";
-    private static final String ENGINE = "docker-compose";
-    private static final String ENGINE_VERSION = "0.0.2";
+    private static final String ENGINE = NAME;
+    private static final String ENGINE_VERSION = "0.2.0";
     private static final String LANGUAGE = "yaml";
-
     private final Map<String, Object> parameters = new HashMap<>();
+    private ProcessBuilderUtilities processBuilderUtilities = new ProcessBuilderUtilities();
+    private DockerComposeVersionGetter dockerComposeVersionGetter = new DockerComposeVersionGetter(processBuilderUtilities);
 
-    public DockerComposeScriptEngineFactory(DockerComposeVersionGetter dockerComposeVersionGetter) {
-        if(dockerComposeVersionGetter == null){
-            throw new NullPointerException("The dockerComposeVersionGetter cannot be null");
-        }
-
-        this.dockerComposeVersionGetter = dockerComposeVersionGetter;
+    public DockerComposeScriptEngineFactory() {
         parameters.put(ScriptEngine.NAME, NAME);
         parameters.put(ScriptEngine.ENGINE_VERSION, ENGINE_VERSION);
         parameters.put(ScriptEngine.LANGUAGE, LANGUAGE);
         parameters.put(ScriptEngine.ENGINE, ENGINE);
+    }
+
+    public DockerComposeScriptEngineFactory(ProcessBuilderUtilities processBuilderUtilities,
+                                            DockerComposeVersionGetter dockerComposeVersionGetter) {
+        this();
+        if (processBuilderUtilities == null || dockerComposeVersionGetter == null) {
+            throw new NullPointerException("processBuilderUtilities and dockerComposeVersionGetter must not be null");
+        }
+        this.processBuilderUtilities = processBuilderUtilities;
+        this.dockerComposeVersionGetter = dockerComposeVersionGetter;
+
     }
 
 
@@ -59,7 +60,7 @@ public class DockerComposeScriptEngineFactory implements ScriptEngineFactory {
 
     @Override
     public List<String> getNames() {
-        return Arrays.asList("docker-compose", "fig");
+        return Arrays.asList(ENGINE, "fig");
     }
 
     @Override

--- a/src/main/java/jsr223/docker/compose/bindings/MapBindingsAdder.java
+++ b/src/main/java/jsr223/docker/compose/bindings/MapBindingsAdder.java
@@ -34,23 +34,21 @@
  */
 package jsr223.docker.compose.bindings;
 
-import java.util.Map;
-
-import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j;
+
+import java.util.Map;
 
 @Log4j
 public class MapBindingsAdder {
 
     /**
-     *
      * @param environment Add strings to environment. Method returns immediately if null.
-     * @param entry Entry containing an object, the object type is checked and handled individually. Method
-     *              returns immediately if null.
+     * @param entry       Entry containing an object, the object type is checked and handled individually. Method
+     *                    returns immediately if null.
      */
     public void addEntryToEnvironmentOtherThanPureStrings(Map<String, String> environment,
-            Map.Entry<String, Object> entry) {
-        if(environment == null || entry == null) {
+                                                          Map.Entry<String, Object> entry) {
+        if (environment == null || entry == null) {
             return;
         }
 
@@ -78,7 +76,7 @@ public class MapBindingsAdder {
     }
 
     private void addEntryToEnvironmentWhichIsAMapContainingStrings(Map<String, String> environment,
-            Map.Entry<String, Object> entry) {
+                                                                   Map.Entry<String, Object> entry) {
         for (Map.Entry<?, ?> mapEntry : ((Map<?, ?>) entry.getValue()).entrySet()) {
             if (mapEntry.getValue() instanceof String && mapEntry.getKey() instanceof String) {
                 environment.put((String) mapEntry.getKey(), (String) mapEntry.getValue());

--- a/src/main/java/jsr223/docker/compose/utils/DockerComposePropertyLoader.java
+++ b/src/main/java/jsr223/docker/compose/utils/DockerComposePropertyLoader.java
@@ -35,6 +35,7 @@
 package jsr223.docker.compose.utils;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j;
 
@@ -45,30 +46,25 @@ import java.util.Properties;
 @Log4j
 public class DockerComposePropertyLoader {
 
-    @lombok.Getter
-    public String dockerHost;
+    private final static String CONFIGURATION_FILE = "config/scriptengines/docker-compose.properties";
+    @Getter
+    private final String dockerHost;
+    @Getter
+    private final String dockerComposeCommand;
+    @Getter
+    private final String sudoCommand;
+    @Getter
+    private final boolean useSudo;
+    private final Properties properties;
 
-    @lombok.Getter
-    public String dockerComposeCommand;
-
-    @lombok.Getter
-    public String sudoCommand;
-
-    @lombok.Getter
-    public boolean useSudo;
-
-    protected Properties properties;
-
-    protected String configurationFile = "config/scriptengines/docker-compose.properties";
-
-    private DockerComposePropertyLoader()  {
+    private DockerComposePropertyLoader() {
         properties = new Properties();
         try {
-            log.debug("Load properties from configuration file: "+configurationFile);
-            properties.load(getClass().getClassLoader().getResourceAsStream(configurationFile));
+            log.debug("Load properties from configuration file: " + CONFIGURATION_FILE);
+            properties.load(getClass().getClassLoader().getResourceAsStream(CONFIGURATION_FILE));
         } catch (IOException | NullPointerException e) {
-            log.info("Configuration file "+configurationFile+" not found. Standard values will be used.");
-            log.debug("Configuration file "+configurationFile+" not found. Standard values will be used.", e);
+            log.info("Configuration file " + CONFIGURATION_FILE + " not found. Standard values will be used.");
+            log.debug("Configuration file " + CONFIGURATION_FILE + " not found. Standard values will be used.", e);
         }
 
         // Get property, specify default value
@@ -83,20 +79,20 @@ public class DockerComposePropertyLoader {
         this.dockerHost = properties.getProperty("docker.host", "");
     }
 
-
-
-
-     /**    Initializes DockerComposePropertyLoader.
-
-      DockerComposePropertyLoaderHolder is loaded on the first execution of DockerComposePropertyLoader.getInstance()
-      or the first access to DockerComposePropertyLoaderHolder.INSTANCE, not before.
-    **/
-     @NoArgsConstructor(access = AccessLevel.PRIVATE)
-    private static class DockerComposePropertyLoaderHolder {
-        private static final DockerComposePropertyLoader INSTANCE = new DockerComposePropertyLoader();
-    }
-
     public static DockerComposePropertyLoader getInstance() {
         return DockerComposePropertyLoaderHolder.INSTANCE;
+    }
+
+    /**
+     * Initializes DockerComposePropertyLoader.
+     * <p>
+     * DockerComposePropertyLoaderHolder is loaded on the first execution of DockerComposePropertyLoader.getInstance()
+     * or the first access to DockerComposePropertyLoaderHolder.INSTANCE, not before.
+     **/
+    private static class DockerComposePropertyLoaderHolder {
+        private static final DockerComposePropertyLoader INSTANCE = new DockerComposePropertyLoader();
+
+        private DockerComposePropertyLoaderHolder() {
+        }
     }
 }

--- a/src/main/java/jsr223/docker/compose/utils/DockerComposeVersionGetter.java
+++ b/src/main/java/jsr223/docker/compose/utils/DockerComposeVersionGetter.java
@@ -15,7 +15,7 @@ import processbuilder.utils.ProcessBuilderUtilities;
 public class DockerComposeVersionGetter {
 
     @NonNull
-    ProcessBuilderUtilities processBuilderUtilities;
+    private ProcessBuilderUtilities processBuilderUtilities;
 
     /**
      * Retrieves the docker compose version.

--- a/src/main/java/jsr223/docker/compose/utils/Log4jConfigurationLoader.java
+++ b/src/main/java/jsr223/docker/compose/utils/Log4jConfigurationLoader.java
@@ -1,0 +1,66 @@
+/*
+ *  *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2016 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s): ActiveEon Team - http://www.activeeon.com
+ *
+ *  * $$ACTIVEEON_CONTRIBUTOR$$
+ */
+package jsr223.docker.compose.utils;
+
+public class Log4jConfigurationLoader {
+
+    private static final String LOG4J_CONFIGURATION_FILE = "config/log/scriptengines.properties";
+
+    public void loadLog4jConfiguration() {
+        // Catch all exceptions to not sacrifice functionality for logging.
+        try {
+            // configure the logger here, quick and dirty
+            org.apache.log4j.PropertyConfigurator.configure(getClass()
+                    .getClassLoader().getResourceAsStream(LOG4J_CONFIGURATION_FILE));
+        } catch (NullPointerException e) { //NOSONAR
+            warnAboutMissingConfigurationFileOnErrorStream();
+        } catch (Exception e) { //NOSONAR
+            warnAboutNotFunctioningLoggingOnErrorStream(e);
+        }
+
+    }
+
+    private void warnAboutNotFunctioningLoggingOnErrorStream(Exception e) {
+        System.err.println("Log4j initialization failed: " + LOG4J_CONFIGURATION_FILE + //NOSONAR
+                ". Docker Compose script engine is functional but logging is disabled." + //NOSONAR
+                "Stacktrace is: "); //NOSONAR
+        e.printStackTrace(); //NOSONAR
+    }
+
+    private void warnAboutMissingConfigurationFileOnErrorStream() {
+        System.err.println("Log4j configuration file not found: " + LOG4J_CONFIGURATION_FILE + //NOSONAR
+                ". Any output for the Docker Compose script engine is disabled."); //NOSONAR
+    }
+}

--- a/src/main/java/processbuilder/utils/ProcessBuilderUtilities.java
+++ b/src/main/java/processbuilder/utils/ProcessBuilderUtilities.java
@@ -7,8 +7,10 @@ import java.io.Reader;
 import java.io.Writer;
 
 import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j;
 
 @NoArgsConstructor
+@Log4j
 public class ProcessBuilderUtilities {
 
     /**
@@ -18,13 +20,13 @@ public class ProcessBuilderUtilities {
      * @param source       Data source.
      * @param attachedSink Data sink.
      */
-    public void attachToInputStream(final Reader source, final Writer attachedSink) {
+    private void attachToInputStream(final Reader source, final Writer attachedSink) {
         new Thread() {
             public void run() {
                 try {
                     pipe(source, attachedSink);
                 } catch (IOException e) {
-                    //Done
+                    log.error("Input stream pipe broke: "+e);
                 }
             }
         }.start();

--- a/src/test/java/jsr223/docker/compose/DockerComposeCommandCreatorTest.java
+++ b/src/test/java/jsr223/docker/compose/DockerComposeCommandCreatorTest.java
@@ -6,9 +6,10 @@ import org.junit.Test;
 import testing.utils.ReflectionUtilities;
 
 import java.lang.reflect.Field;
-import java.util.List;
 
 public class DockerComposeCommandCreatorTest {
+
+    private final DockerComposeCommandCreator dockerCommandCreator = new DockerComposeCommandCreator();
 
     @Test
     public void testDockerExecutionCommandWithSudo() throws NoSuchFieldException, IllegalAccessException {
@@ -29,61 +30,42 @@ public class DockerComposeCommandCreatorTest {
     }
 
     /**
-     * Test whether the stop command has the right structure.
-     * @throws NoSuchFieldException
-     * @throws IllegalAccessException
-     */
-    @Test
-    public void testDockerComposeStopCommand() throws NoSuchFieldException, IllegalAccessException {
-        String[] command = DockerComposeCommandCreator.createDockerComposeStopCommand();
-        // Running index; which position of array will currently be checked.
-        int index = 0;
-
-        // Check if sudo is added correctly
-        index = checkSudoAndComposeCommand(command, index);
-
-        // Check if stop argument is next
-        Assert.assertEquals("Stop option must be used.",
-                ReflectionUtilities.makeFieldAccessible("stopContainerArgument",
-                        DockerComposeCommandCreator.class).get(new DockerComposeCommandCreator()),
-        command[index++]);
-    }
-
-    /**
      * Test whether the remove command has the right structure.
+     *
      * @throws NoSuchFieldException
      * @throws IllegalAccessException
      */
     @Test
-    public void testDockerComposeRemoveCommand() throws NoSuchFieldException, IllegalAccessException {
-        String[] command = DockerComposeCommandCreator.createDockerComposeRemoveCommand();
+    public void testDockerComposeDownCommand() throws NoSuchFieldException, IllegalAccessException {
+        String[] command = dockerCommandCreator.createDockerComposeDownCommand();
         // Running index; which position of array will currently be checked.
         int index = 0;
 
         // Check if sudo is added correctly
         index = checkSudoAndComposeCommand(command, index);
 
-        // Check if stop argument is next
-        Assert.assertEquals("Stop option must be used.",
-                ReflectionUtilities.makeFieldAccessible("removeContainerArgument",
-                        DockerComposeCommandCreator.class).get(new DockerComposeCommandCreator()),
+
+
+        // Check if stop and remove (down) argument is next
+        Assert.assertEquals("Down option must be used.",
+                dockerCommandCreator.STOP_AND_REMOVE_CONTAINER_ARGUMENT,
                 command[index++]);
 
-        // Check if stop argument is next
-        Assert.assertEquals("Stop option must be use force argument.",
-                ReflectionUtilities.makeFieldAccessible("removeWithForceContainerArgument",
-                        DockerComposeCommandCreator.class).get(new DockerComposeCommandCreator()),
+        // Check if volume argument is next
+        Assert.assertEquals("Volume option must be used after down.",
+                dockerCommandCreator.VOLUMES_ARGUMENT,
                 command[index++]);
     }
 
     /**
-     * Check whether the exeuction command has the right structure.
+     * Check whether the execution command has the right structure.
+     *
      * @throws NoSuchFieldException
      * @throws IllegalAccessException
      */
     @Test
     public void testDockerComposeExecutionCommand() throws NoSuchFieldException, IllegalAccessException {
-        String[] command = DockerComposeCommandCreator.createDockerComposeExecutionCommand();
+        String[] command = dockerCommandCreator.createDockerComposeExecutionCommand();
         int index = 0;
 
         // Check if sudo and compose command are added correctly
@@ -92,20 +74,17 @@ public class DockerComposeCommandCreatorTest {
 
         // Check if file argument is used
         Assert.assertEquals("File option must be used.",
-                ReflectionUtilities.makeFieldAccessible("filenameArgument",
-                        DockerComposeCommandCreator.class).get(new DockerComposeCommandCreator()),
+                DockerComposeCommandCreator.FILENAME_ARGUMENT,
                 command[index++]);
 
         // Check if correct filename is used
         Assert.assertEquals("Correct filename must be used in command.",
-                ReflectionUtilities.makeFieldAccessible("yamlFileName",
-                        DockerComposeCommandCreator.class).get(new DockerComposeCommandCreator()),
+                DockerComposeCommandCreator.YAML_FILE_NAME,
                 command[index++]);
 
         // Check whether correct start command for yaml file is used
         Assert.assertEquals("Correct argument for compose command must be used.",
-                ReflectionUtilities.makeFieldAccessible("setupContainerArgument",
-                        DockerComposeCommandCreator.class).get(new DockerComposeCommandCreator()),
+                DockerComposeCommandCreator.START_CONTAINER_ARGUMENT,
                 command[index++]);
     }
 

--- a/src/test/java/jsr223/docker/compose/DockerComposeScriptEngineFactoryTest.java
+++ b/src/test/java/jsr223/docker/compose/DockerComposeScriptEngineFactoryTest.java
@@ -1,39 +1,45 @@
 package jsr223.docker.compose;
 
-import javax.script.ScriptEngine;
-
 import jsr223.docker.compose.utils.DockerComposeVersionGetter;
 import org.junit.Test;
 import processbuilder.ProcessBuilderFactory;
 import processbuilder.utils.ProcessBuilderUtilities;
 
+import javax.script.ScriptEngine;
+
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.contains;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class DockerComposeScriptEngineFactoryTest {
 
-    private String testVersion = "someVersion 44";
-
     @Test(expected = NullPointerException.class)
     public void testThatVersionGetterCannotBeNull() {
-        new DockerComposeScriptEngineFactory(null);
+        new DockerComposeScriptEngineFactory(new ProcessBuilderUtilities(), null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testThatProcessBuilderCannotBeNull() {
+        new DockerComposeScriptEngineFactory(null, new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testThatVersionGetterAndProcessBuilderCannotBeNull() {
+        new DockerComposeScriptEngineFactory(null, null);
     }
 
     @Test
     public void testThatDockerComposeVersionGetterIsUsed() {
         DockerComposeVersionGetter dockerComposeVersionGetterMock = mock(DockerComposeVersionGetter.class);
+        String testVersion = "someVersion 44";
         when(dockerComposeVersionGetterMock.getDockerComposeVersion(
                 any(ProcessBuilderFactory.class))).thenReturn(testVersion);
 
-        DockerComposeScriptEngineFactory dockerComposeScriptEngineFactory = new DockerComposeScriptEngineFactory(
-                dockerComposeVersionGetterMock);
+        DockerComposeScriptEngineFactory dockerComposeScriptEngineFactory =
+                new DockerComposeScriptEngineFactory(new ProcessBuilderUtilities(),
+                        dockerComposeVersionGetterMock);
 
         assertThat(dockerComposeScriptEngineFactory.getLanguageVersion(), is(testVersion));
     }
@@ -41,7 +47,7 @@ public class DockerComposeScriptEngineFactoryTest {
     @Test
     public void testThatDockerComposeScriptEngineFactoryReturnsScriptEngine() {
         DockerComposeScriptEngineFactory dockerComposeScriptEngineFactory = new DockerComposeScriptEngineFactory(
-                new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
+                new ProcessBuilderUtilities(), new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
 
         assertThat(dockerComposeScriptEngineFactory.getScriptEngine() instanceof DockerComposeScriptEngine,
                 is(true));
@@ -50,7 +56,7 @@ public class DockerComposeScriptEngineFactoryTest {
     @Test
     public void testThatDockerComposeScriptEngineFactoryReturnsNonNullParameterName() {
         DockerComposeScriptEngineFactory dockerComposeScriptEngineFactory = new DockerComposeScriptEngineFactory(
-                new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
+                new ProcessBuilderUtilities(),new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
 
         assertThat(dockerComposeScriptEngineFactory.getParameter(ScriptEngine.NAME), is(notNullValue()));
     }
@@ -58,7 +64,7 @@ public class DockerComposeScriptEngineFactoryTest {
     @Test
     public void testThatDockerComposeScriptEngineFactoryReturnsNonNullParameterEngineVersion() {
         DockerComposeScriptEngineFactory dockerComposeScriptEngineFactory = new DockerComposeScriptEngineFactory(
-                new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
+                new ProcessBuilderUtilities(), new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
 
         assertThat(dockerComposeScriptEngineFactory.getParameter(ScriptEngine.ENGINE_VERSION),
                 is(notNullValue()));
@@ -67,7 +73,7 @@ public class DockerComposeScriptEngineFactoryTest {
     @Test
     public void testThatDockerComposeScriptEngineFactoryReturnsNonNullParameterLanguage() {
         DockerComposeScriptEngineFactory dockerComposeScriptEngineFactory = new DockerComposeScriptEngineFactory(
-                new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
+                new ProcessBuilderUtilities(), new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
 
         assertThat(dockerComposeScriptEngineFactory.getParameter(ScriptEngine.LANGUAGE), is(notNullValue()));
     }
@@ -75,7 +81,7 @@ public class DockerComposeScriptEngineFactoryTest {
     @Test
     public void testThatDockerComposeScriptEngineFactoryReturnsNonNullParameterEngine() {
         DockerComposeScriptEngineFactory dockerComposeScriptEngineFactory = new DockerComposeScriptEngineFactory(
-                new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
+                new ProcessBuilderUtilities(), new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
 
         assertThat(dockerComposeScriptEngineFactory.getParameter(ScriptEngine.ENGINE), is(notNullValue()));
     }
@@ -83,7 +89,7 @@ public class DockerComposeScriptEngineFactoryTest {
     @Test
     public void testThatDockerComposeScriptEngineFactoryReturnsNonNullLanguageName() {
         DockerComposeScriptEngineFactory dockerComposeScriptEngineFactory = new DockerComposeScriptEngineFactory(
-                new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
+                new ProcessBuilderUtilities(), new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
 
         assertThat(dockerComposeScriptEngineFactory.getEngineName(), is(notNullValue()));
     }
@@ -91,7 +97,7 @@ public class DockerComposeScriptEngineFactoryTest {
     @Test
     public void testThatDockerComposeScriptEngineFactoryNamesContainsDockerCompose() {
         DockerComposeScriptEngineFactory dockerComposeScriptEngineFactory = new DockerComposeScriptEngineFactory(
-                new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
+                new ProcessBuilderUtilities(), new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
 
         assertThat(dockerComposeScriptEngineFactory.getNames(), hasItem(containsString("docker-compose")));
     }
@@ -99,7 +105,7 @@ public class DockerComposeScriptEngineFactoryTest {
     @Test
     public void testThatDockerComposeScriptEngineFactoryMimesTypesContainsYaml() {
         DockerComposeScriptEngineFactory dockerComposeScriptEngineFactory = new DockerComposeScriptEngineFactory(
-                new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
+                new ProcessBuilderUtilities(), new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
 
         assertThat(dockerComposeScriptEngineFactory.getMimeTypes(), hasItem(containsString("yaml")));
     }
@@ -107,7 +113,7 @@ public class DockerComposeScriptEngineFactoryTest {
     @Test
     public void testThatDockerComposeScriptEngineFactoryExtensionContainsYaml() {
         DockerComposeScriptEngineFactory dockerComposeScriptEngineFactory = new DockerComposeScriptEngineFactory(
-                new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
+                new ProcessBuilderUtilities(), new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
 
         assertThat(dockerComposeScriptEngineFactory.getExtensions(), hasItem(containsString("yaml")));
     }
@@ -115,7 +121,7 @@ public class DockerComposeScriptEngineFactoryTest {
     @Test
     public void testThatDockerComposeScriptEngineFactoryExtensionContainsYml() {
         DockerComposeScriptEngineFactory dockerComposeScriptEngineFactory = new DockerComposeScriptEngineFactory(
-                new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
+                new ProcessBuilderUtilities(), new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
 
         assertThat(dockerComposeScriptEngineFactory.getExtensions(), hasItem(containsString("yml")));
     }
@@ -123,7 +129,7 @@ public class DockerComposeScriptEngineFactoryTest {
     @Test
     public void testThatDockerComposeScriptEngineFactoryEngineVersionIsNonNull() {
         DockerComposeScriptEngineFactory dockerComposeScriptEngineFactory = new DockerComposeScriptEngineFactory(
-                new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
+                new ProcessBuilderUtilities(), new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
 
         assertThat(dockerComposeScriptEngineFactory.getEngineVersion(), is(notNullValue()));
     }
@@ -131,7 +137,7 @@ public class DockerComposeScriptEngineFactoryTest {
     @Test
     public void testThatDockerComposeScriptEngineFactoryLanguageIsNonNull() {
         DockerComposeScriptEngineFactory dockerComposeScriptEngineFactory = new DockerComposeScriptEngineFactory(
-                new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
+                new ProcessBuilderUtilities(), new DockerComposeVersionGetter(new ProcessBuilderUtilities()));
 
         assertThat(dockerComposeScriptEngineFactory.getLanguageName(), is(notNullValue()));
     }

--- a/src/test/java/jsr223/docker/compose/bindings/MapBindingsAdderTest.java
+++ b/src/test/java/jsr223/docker/compose/bindings/MapBindingsAdderTest.java
@@ -1,15 +1,13 @@
 package jsr223.docker.compose.bindings;
 
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.script.ScriptException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.script.ScriptException;
-
-import org.junit.Assert;
-import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertThat;
 
@@ -26,7 +24,7 @@ public class MapBindingsAdderTest {
         nullValues.put(null, null);
 
         // Iterate through the null values and pass them to the add method.
-        for ( Map.Entry<String, Object> entry : nullValues.entrySet()) {
+        for (Map.Entry<String, Object> entry : nullValues.entrySet()) {
             mapBindingsAdder.addEntryToEnvironmentOtherThanPureStrings(environment, entry);
         }
 
@@ -44,7 +42,7 @@ public class MapBindingsAdderTest {
         variableMap.put("greetings", "Hello World");
 
         // Iterate through the null values and pass them to the add method.
-        for ( Map.Entry<String, Object> entry : variableMap.entrySet()) {
+        for (Map.Entry<String, Object> entry : variableMap.entrySet()) {
             mapBindingsAdder.addEntryToEnvironmentOtherThanPureStrings(null, entry);
         }
     }
@@ -72,12 +70,12 @@ public class MapBindingsAdderTest {
         outsideMap.put("variables", variableMap);
 
         // Add map which contains map
-        for ( Map.Entry<String, Object> entry : outsideMap.entrySet()) {
+        for (Map.Entry<String, Object> entry : outsideMap.entrySet()) {
             mapBindingsAdder.addEntryToEnvironmentOtherThanPureStrings(environment, entry);
         }
 
-        assertThat(environment, hasEntry("container","dockerfile/ubuntu" ));
-        assertThat(environment, hasEntry("greetings","Hello World"));
+        assertThat(environment, hasEntry("container", "dockerfile/ubuntu"));
+        assertThat(environment, hasEntry("greetings", "Hello World"));
     }
 
 }

--- a/src/test/java/jsr223/docker/compose/utils/Log4jConfigurationLoaderTest.java
+++ b/src/test/java/jsr223/docker/compose/utils/Log4jConfigurationLoaderTest.java
@@ -1,0 +1,18 @@
+package jsr223.docker.compose.utils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class Log4jConfigurationLoaderTest {
+    @Spy
+    Log4jConfigurationLoader log4jConfigurationLoader;
+
+    @Test
+    public void loadLog4jConfigurationDOesntThrowExceptionIfFileIfFileIsNotPresent() throws Exception {
+        log4jConfigurationLoader.loadLog4jConfiguration();
+    }
+
+}

--- a/src/test/java/jsr223/docker/compose/yaml/VariablesReplacerTest.java
+++ b/src/test/java/jsr223/docker/compose/yaml/VariablesReplacerTest.java
@@ -14,11 +14,11 @@ import static org.junit.Assert.assertThat;
 
 public class VariablesReplacerTest {
 
-    final static String yamlFileWithVariables = "$name:\n"
+    private final static String yamlFileWithVariables = "$name:\n"
             + "    image: $container\n"
             + "    command: echo \"$greetings\"";
 
-    final static String yamlFileExpected = "EchoUbuntu:\n"
+    private final static String yamlFileExpected = "EchoUbuntu:\n"
             + "    image: dockerfile/ubuntu\n"
             + "    command: echo \"Hello World\"";
 


### PR DESCRIPTION
…ovements.

Increase the script-engine version to 0.2.0.

The docker compose stop and docker compose remove command were both too slow. So the ProActive node killed the thread during the removal process.

The docker compose down command is now utilised to remove and kill the container within one go, which increases the likelihood of the container actually being removed.

The DockerComposeScriptEngineFactory got its own ProcessBuilder service class.

The DockerComposeScriptEngineFactory got a standard constructor with which it can be initialized at during the node startup.
