### PR TITLE
Better handle the parameters of the docker-compose command line tool

### DIFF
--- a/src/main/java/jsr223/docker/compose/DockerComposeCommandCreator.java
+++ b/src/main/java/jsr223/docker/compose/DockerComposeCommandCreator.java
@@ -27,7 +27,9 @@ package jsr223.docker.compose;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
+import jsr223.docker.compose.utils.CommandlineOptionsFromBindingsExtractor.OptionType;
 import jsr223.docker.compose.utils.DockerComposePropertyLoader;
 import lombok.NoArgsConstructor;
 
@@ -68,9 +70,14 @@ public class DockerComposeCommandCreator {
      * @return A String array which contains the command as a separate @String and each
      * argument as a separate String.
      */
-    public String[] createDockerComposeExecutionCommand(List<String> dockerComposeUpCommandOptions) {
+    public String[] createDockerComposeExecutionCommand(Map<OptionType, List<String>> commandOptions) {
         List<String> command = new ArrayList<>();
+        List<String> generalOptions = new ArrayList<>(commandOptions.get(OptionType.GENERAL_OPTION));
+        List<String> upOptions = new ArrayList<>(commandOptions.get(OptionType.UP_OPTION));
         addSudoAndDockerComposeCommand(command);
+
+        // Add the general parameters
+        command.addAll(generalOptions);
 
         // Add filename argument
         command.add(FILENAME_ARGUMENT);
@@ -81,7 +88,7 @@ public class DockerComposeCommandCreator {
         // Start container with argument
         command.add(START_CONTAINER_ARGUMENT);
 
-        command.addAll(dockerComposeUpCommandOptions);
+        command.addAll(upOptions);
 
         return command.toArray(new String[command.size()]);
     }

--- a/src/main/java/jsr223/docker/compose/DockerComposeScriptEngine.java
+++ b/src/main/java/jsr223/docker/compose/DockerComposeScriptEngine.java
@@ -38,6 +38,7 @@ import jsr223.docker.compose.bindings.MapBindingsAdder;
 import jsr223.docker.compose.bindings.StringBindingsAdder;
 import jsr223.docker.compose.file.write.ConfigurationFileWriter;
 import jsr223.docker.compose.utils.CommandlineOptionsFromBindingsExtractor;
+import jsr223.docker.compose.utils.CommandlineOptionsFromBindingsExtractor.OptionType;
 import jsr223.docker.compose.utils.DockerComposePropertyLoader;
 import jsr223.docker.compose.utils.Log4jConfigurationLoader;
 import jsr223.docker.compose.utils.ScriptContextBindingsExtractor;
@@ -76,10 +77,10 @@ public class DockerComposeScriptEngine extends AbstractScriptEngine {
     @Override
     public Object eval(String script, ScriptContext context) throws ScriptException {
         Bindings bindings = scriptContextBindingsExtractor.extractFrom(context);
-        List<String> dockerComposeOptions = commandlineOptionsFromBindingsExtractor.getDockerComposeCommandOptions(bindings);
+        Map<OptionType, List<String>> options = commandlineOptionsFromBindingsExtractor.getDockerComposeCommandOptions(bindings);
 
         // Create docker compose command
-        String[] dockerComposeCommand = dockerComposeCommandCreator.createDockerComposeExecutionCommand(dockerComposeOptions);
+        String[] dockerComposeCommand = dockerComposeCommandCreator.createDockerComposeExecutionCommand(options);
 
         // Create a process builder
         ProcessBuilder processBuilder = SingletonProcessBuilderFactory.getInstance()

--- a/src/test/java/jsr223/docker/compose/DockerComposeCommandCreatorTest.java
+++ b/src/test/java/jsr223/docker/compose/DockerComposeCommandCreatorTest.java
@@ -30,11 +30,14 @@ import static org.junit.Assert.assertTrue;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import jsr223.docker.compose.utils.CommandlineOptionsFromBindingsExtractor.OptionType;
 import jsr223.docker.compose.utils.DockerComposePropertyLoader;
 import testing.utils.ReflectionUtilities;
 
@@ -88,11 +91,12 @@ public class DockerComposeCommandCreatorTest {
 
     @Test
     public void testThatDockerComposeUpOptionsArePlacedBehindUp() {
-        List<String> command = Arrays.asList(dockerCommandCreator.createDockerComposeExecutionCommand(Arrays.asList("--option1")));
+        Map<OptionType, List<String>> options = getOptions(Collections.EMPTY_LIST, Arrays.asList("--option1"));
+        List<String> cmd = Arrays.asList(dockerCommandCreator.createDockerComposeExecutionCommand(options));
 
-        int indexOfUp = command.indexOf(DockerComposeCommandCreator.START_CONTAINER_ARGUMENT);
+        int indexOfUp = cmd.indexOf(DockerComposeCommandCreator.START_CONTAINER_ARGUMENT);
 
-        assertTrue(command.get(indexOfUp + 1).equals("--option1"));
+        assertTrue(cmd.get(indexOfUp + 1).equals("--option1"));
     }
 
     /**
@@ -103,7 +107,7 @@ public class DockerComposeCommandCreatorTest {
      */
     @Test
     public void testDockerComposeExecutionCommand() throws NoSuchFieldException, IllegalAccessException {
-        String[] command = dockerCommandCreator.createDockerComposeExecutionCommand(Collections.<String> emptyList());
+        String[] command = dockerCommandCreator.createDockerComposeExecutionCommand(getOptions(null, null));
         int index = 0;
 
         // Check if sudo and compose command are added correctly
@@ -138,5 +142,20 @@ public class DockerComposeCommandCreatorTest {
                             DockerComposePropertyLoader.getInstance().getDockerComposeCommand(),
                             command[index++]);
         return index;
+    }
+
+    private Map<OptionType, List<String>> getOptions(List<String> generalOptions, List<String> upOptions) {
+        Map<OptionType, List<String>> options = new EnumMap<OptionType, List<String>>(OptionType.class);
+        if (generalOptions != null) {
+            options.put(OptionType.GENERAL_OPTION, generalOptions);
+        } else {
+            options.put(OptionType.GENERAL_OPTION, Collections.<String> emptyList());
+        }
+        if (upOptions != null) {
+            options.put(OptionType.UP_OPTION, upOptions);
+        } else {
+            options.put(OptionType.UP_OPTION, Collections.<String> emptyList());
+        }
+        return options;
     }
 }

--- a/src/test/java/jsr223/docker/compose/utils/CommandlineOptionsFromBindingsExtractorTest.java
+++ b/src/test/java/jsr223/docker/compose/utils/CommandlineOptionsFromBindingsExtractorTest.java
@@ -36,6 +36,8 @@ import javax.script.SimpleBindings;
 
 import org.junit.Test;
 
+import jsr223.docker.compose.utils.CommandlineOptionsFromBindingsExtractor.OptionType;
+
 
 /**
  * @author ActiveEon Team
@@ -51,13 +53,23 @@ public class CommandlineOptionsFromBindingsExtractorTest {
         Map<String, String> genericInformation = new HashMap<>();
         genericInformation.put(CommandlineOptionsFromBindingsExtractor.DOCKER_COMPOSE_UP_COMMANDLINE_OPTIONS_KEY,
                                "--option1 --option2");
+        genericInformation.put(CommandlineOptionsFromBindingsExtractor.DOCKER_COMPOSE_COMMANDLINE_OPTIONS_KEY,
+                               "--verbose --host localhost");
+
         bindings.put(CommandlineOptionsFromBindingsExtractor.GENERIC_INFORMATION_KEY, genericInformation);
 
-        List<String> options = commandlineOptionsFromBindingsExtractor.getDockerComposeCommandOptions(bindings);
+        Map<OptionType, List<String>> options = commandlineOptionsFromBindingsExtractor.getDockerComposeCommandOptions(bindings);
+        List<String> upOptions = options.get(OptionType.UP_OPTION);
+        List<String> generalOptions = options.get(OptionType.GENERAL_OPTION);
 
-        assertTrue(options.contains("--option1"));
-        assertTrue(options.contains("--option2"));
-        assertTrue(options.size() == 2);
+        assertTrue(upOptions.contains("--option1"));
+        assertTrue(upOptions.contains("--option2"));
+        assertTrue(upOptions.size() == 2);
+
+        assertTrue(generalOptions.contains("--verbose"));
+        assertTrue(generalOptions.contains("--host"));
+        assertTrue(generalOptions.contains("localhost"));
+        assertTrue(generalOptions.size() == 3);
     }
 
     @Test
@@ -72,11 +84,12 @@ public class CommandlineOptionsFromBindingsExtractorTest {
                                "!SPLIT!");
         bindings.put(CommandlineOptionsFromBindingsExtractor.GENERIC_INFORMATION_KEY, genericInformation);
 
-        List<String> options = commandlineOptionsFromBindingsExtractor.getDockerComposeCommandOptions(bindings);
+        Map<OptionType, List<String>> options = commandlineOptionsFromBindingsExtractor.getDockerComposeCommandOptions(bindings);
+        List<String> upOptions = options.get(OptionType.UP_OPTION);
 
-        assertTrue(options.contains("--option1"));
-        assertTrue(options.contains("--option2"));
-        assertTrue(options.size() == 2);
+        assertTrue(upOptions.contains("--option1"));
+        assertTrue(upOptions.contains("--option2"));
+        assertTrue(upOptions.size() == 2);
     }
 
     @Test
@@ -87,17 +100,18 @@ public class CommandlineOptionsFromBindingsExtractorTest {
         Map<String, String> genericInformation = new HashMap<>();
         bindings.put(CommandlineOptionsFromBindingsExtractor.GENERIC_INFORMATION_KEY, genericInformation);
 
-        List<String> options = commandlineOptionsFromBindingsExtractor.getDockerComposeCommandOptions(bindings);
+        Map<OptionType, List<String>> options = commandlineOptionsFromBindingsExtractor.getDockerComposeCommandOptions(bindings);
+        List<String> upOptions = options.get(OptionType.UP_OPTION);
 
-        assertTrue(options.size() == 0);
+        assertTrue(upOptions.size() == 0);
     }
 
     @Test
-    public void testThatNoGenericInformationReturnEmptyList() {
+    public void testThatNoGenericInformationReturnEmptyMap() {
         CommandlineOptionsFromBindingsExtractor commandlineOptionsFromBindingsExtractor = new CommandlineOptionsFromBindingsExtractor();
 
         Bindings bindings = new SimpleBindings();
-        List<String> options = commandlineOptionsFromBindingsExtractor.getDockerComposeCommandOptions(bindings);
+        Map<OptionType, List<String>> options = commandlineOptionsFromBindingsExtractor.getDockerComposeCommandOptions(bindings);
 
         assertTrue(options.size() == 0);
     }


### PR DESCRIPTION
Some parameters need to be set before the action (up, down, build, etc) so they need to be separated in distinct generic info parameters for the command to run successfully.