### PR TITLE
Improve DockerFile script engine

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.3.3
+version=0.3.4
 groupId=jsr223
 artifactId=jsr223-docker-compose

--- a/src/main/java/jsr223/docker/file/DockerFilePropertyLoader.java
+++ b/src/main/java/jsr223/docker/file/DockerFilePropertyLoader.java
@@ -49,8 +49,6 @@ public class DockerFilePropertyLoader {
 
     public static final String DOCKER_FILE_KEEP = "docker.file.keepimage";
 
-    public static final String DOCKER_CONTAINER_KEEP = "docker.file.keepcontainer";
-
     @Getter
     @Setter
     private String dockerHost;

--- a/src/test/java/jsr223/docker/file/DockerFileScriptEngineTest.java
+++ b/src/test/java/jsr223/docker/file/DockerFileScriptEngineTest.java
@@ -71,6 +71,119 @@ public class DockerFileScriptEngineTest {
     }
 
     @Test
+    public void testReuseImage() throws Exception {
+        assumeTrue(dockerCommandExists());
+
+        String imageName = "my-image";
+
+        String dockerScript = "FROM ubuntu:18.04\n" + "RUN echo \"Hello\"";
+
+        SimpleScript ss = new SimpleScript(dockerScript, DockerFileScriptEngineFactory.NAME);
+        TaskScript taskScript = new TaskScript(ss);
+        HashMap<String, Serializable> variablesMap = new HashMap<>(2);
+        variablesMap.put(SchedulerVars.PA_JOB_ID.name(), "1");
+        variablesMap.put(SchedulerVars.PA_TASK_ID.name(), "2");
+        HashMap<String, String> genericInfo = new HashMap<>(2);
+        genericInfo.put(DockerFileScriptEngine.DOCKER_IMAGE_TAG_GI, imageName);
+        genericInfo.put(DockerFileScriptEngine.DOCKER_ACTIONS_GI, "build");
+
+        Map<String, Object> aBindings = ImmutableMap.of(SchedulerConstants.VARIABLES_BINDING_NAME,
+                                                        (Object) variablesMap,
+                                                        SchedulerConstants.GENERIC_INFO_BINDING_NAME,
+                                                        genericInfo);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        runAndGetOutput(taskScript, aBindings, output);
+
+        Assert.assertTrue("Output should contain the dedicated image name", output.toString().contains(imageName));
+
+        genericInfo.put(DockerFileScriptEngine.DOCKER_ACTIONS_GI, "run,stop,rmi");
+
+        output = new ByteArrayOutputStream();
+
+        runAndGetOutput(taskScript, aBindings, output);
+
+        Assert.assertTrue("Output should contain the dedicated container name",
+                          output.toString().contains(DockerFileScriptEngine.DEFAULT_CONTAINER_NAME + "_1t2"));
+    }
+
+    /**
+     * This complex test first builds and image and run a container in background
+     * it then executes a command inside the container
+     * finally, it stops the container and removes the image
+     * @throws Exception
+     */
+    @Test
+    public void testReuseImageAndContainer() throws Exception {
+        assumeTrue(dockerCommandExists());
+
+        String imageName = "my-image";
+        String containerName = "my-container";
+
+        String dockerScript = "FROM ubuntu:18.04\n";
+
+        // Build and run the container in background mode
+        SimpleScript ss = new SimpleScript(dockerScript, DockerFileScriptEngineFactory.NAME);
+        TaskScript taskScript = new TaskScript(ss);
+        HashMap<String, Serializable> variablesMap = new HashMap<>(2);
+        variablesMap.put(SchedulerVars.PA_JOB_ID.name(), "1");
+        variablesMap.put(SchedulerVars.PA_TASK_ID.name(), "2");
+        HashMap<String, String> genericInfo = new HashMap<>(3);
+        genericInfo.put(DockerFileScriptEngine.DOCKER_IMAGE_TAG_GI, imageName);
+        genericInfo.put(DockerFileScriptEngine.DOCKER_CONTAINER_TAG_GI, containerName);
+        genericInfo.put(DockerFileCommandCreator.DOCKER_RUN_COMMANDLINE_OPTIONS_KEY, "-t -d");
+        genericInfo.put(DockerFileScriptEngine.DOCKER_ACTIONS_GI, "build,run");
+
+        Map<String, Object> aBindings = ImmutableMap.of(SchedulerConstants.VARIABLES_BINDING_NAME,
+                                                        (Object) variablesMap,
+                                                        SchedulerConstants.GENERIC_INFO_BINDING_NAME,
+                                                        genericInfo);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        runAndGetOutput(taskScript, aBindings, output);
+
+        Assert.assertTrue("Output should contain the dedicated image name", output.toString().contains(imageName));
+
+        Assert.assertTrue("Output should contain the dedicated container name",
+                          output.toString().contains(containerName));
+
+        // Execute a command inside the container
+        String messageToPrint = "my test message";
+
+        genericInfo.put(DockerFileCommandCreator.DOCKER_FILE_COMMANDLINE_OPTIONS_SPLIT_REGEX_KEY, "!SPLIT!");
+        genericInfo.put(DockerFileCommandCreator.DOCKER_EXEC_COMMAND_KEY,
+                        "/bin/sh!SPLIT!-c!SPLIT!echo '" + messageToPrint + "'");
+        genericInfo.put(DockerFileScriptEngine.DOCKER_ACTIONS_GI, "exec");
+
+        output = new ByteArrayOutputStream();
+
+        runAndGetOutput(taskScript, aBindings, output);
+
+        Assert.assertTrue("Output should contain the custom message printed by the exec command",
+                          output.toString().contains(messageToPrint));
+
+        // Clean up
+        genericInfo.put(DockerFileScriptEngine.DOCKER_ACTIONS_GI, "stop,rmi");
+        runAndGetOutput(taskScript, aBindings, output);
+    }
+
+    private void runAndGetOutput(TaskScript taskScript, Map<String, Object> aBindings, ByteArrayOutputStream output) {
+        ScriptResult<Serializable> res = taskScript.execute(aBindings,
+                                                            new PrintStream(output),
+                                                            new PrintStream(output));
+
+        System.out.println("Script output:");
+        System.out.println(output.toString());
+
+        System.out.println("Script Exception:");
+        System.out.println(res.getException());
+
+        Assert.assertFalse(res.errorOccured());
+    }
+
+    @Test
     public void testContainerAndImageShouldUseJobTaskIds() throws Exception {
         assumeTrue(dockerCommandExists());
 
@@ -88,17 +201,7 @@ public class DockerFileScriptEngineTest {
 
         ByteArrayOutputStream output = new ByteArrayOutputStream();
 
-        ScriptResult<Serializable> res = taskScript.execute(aBindings,
-                                                            new PrintStream(output),
-                                                            new PrintStream(output));
-
-        System.out.println("Script output:");
-        System.out.println(output.toString());
-
-        System.out.println("Script Exception:");
-        System.out.println(res.getException());
-
-        Assert.assertFalse(res.errorOccured());
+        runAndGetOutput(taskScript, aBindings, output);
 
         Assert.assertTrue("Output should contain the dedicated image name",
                           output.toString().contains(DockerFileScriptEngine.DEFAULT_IMAGE_NAME + "_1t2"));
@@ -125,17 +228,7 @@ public class DockerFileScriptEngineTest {
 
         ByteArrayOutputStream output = new ByteArrayOutputStream();
 
-        ScriptResult<Serializable> res = taskScript.execute(aBindings,
-                                                            new PrintStream(output),
-                                                            new PrintStream(output));
-
-        System.out.println("Script output:");
-        System.out.println(output.toString());
-
-        System.out.println("Script Exception:");
-        System.out.println(res.getException());
-
-        Assert.assertFalse(res.errorOccured());
+        runAndGetOutput(taskScript, aBindings, output);
 
         Assert.assertTrue("Docker file should be created in temp directory",
                           new File(tempDir, DockerFileCommandCreator.FILENAME).exists());
@@ -152,18 +245,9 @@ public class DockerFileScriptEngineTest {
 
         ByteArrayOutputStream output = new ByteArrayOutputStream();
 
-        ScriptResult<Serializable> res = taskScript.execute(ImmutableMap.of(SchedulerConstants.GENERIC_INFO_BINDING_NAME,
-                                                                            Collections.EMPTY_MAP),
-                                                            new PrintStream(output),
-                                                            new PrintStream(output));
-
-        System.out.println("Script output:");
-        System.out.println(output.toString());
-
-        System.out.println("Script Exception:");
-        System.out.println(res.getException());
-
-        Assert.assertFalse(res.errorOccured());
+        runAndGetOutput(taskScript,
+                        ImmutableMap.of(SchedulerConstants.GENERIC_INFO_BINDING_NAME, Collections.EMPTY_MAP),
+                        output);
 
         Assert.assertTrue("Captured output should appear", output.toString().contains(capturedOutput));
     }


### PR DESCRIPTION
 - Allow defining the image and container name as generic information
 - Allow defining the actions to execute as generic information (default is build,run,stop,rmi
 - Introduce the exec action, which allows to do docker exec inside a running container
 - Add relevant unit tests